### PR TITLE
Update LegalCase type and cleanup

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,0 @@
-import axios from "axios";
-
-export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || "http://localhost:8000",
-});

--- a/frontend/src/entities/case/types.ts
+++ b/frontend/src/entities/case/types.ts
@@ -1,6 +1,7 @@
 export interface LegalCase {
   id: number;
   title: string;
-  category: string;
+  description: string;
   created_at: string;      // ISO-строка
+  category: { id: number; name: string };
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,7 +35,7 @@ export default function Dashboard() {
 
   /* группировка по категориям */
   const grouped = cases.reduce<Record<string, LegalCase[]>>((acc, c) => {
-    (acc[c.category] ||= []).push(c);
+    (acc[c.category.name] ||= []).push(c);
     return acc;
   }, {});
 


### PR DESCRIPTION
## Summary
- make `category` on `LegalCase` an object rather than a string
- update Dashboard grouping logic to use `category.name`
- remove unused API client

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffe86580c8333bbb6c44d19811a0a