### PR TITLE
Add document model and upload API

### DIFF
--- a/backend/app/api/cases.py
+++ b/backend/app/api/cases.py
@@ -1,9 +1,13 @@
 # backend/app/api/cases.py
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from fastapi.responses import FileResponse
+from uuid import uuid4
+import os
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from ..core.database import get_async_session          # ← новое
+from ..core.config import settings
 from .. import models, schemas
 
 router = APIRouter(prefix="/cases", tags=["cases"])
@@ -39,5 +43,44 @@ async def upload_documents(
     case = await db.get(models.Case, case_id)
     if not case:
         raise HTTPException(404, "Case not found")
-    # TODO: сохранить файлы
-    return {"ok": True, "uploaded": len(files)}
+
+    os.makedirs(settings.FILE_STORAGE_PATH, exist_ok=True)
+    saved = 0
+    for f in files:
+        unique = f"{uuid4()}_{f.filename}"
+        dest = os.path.join(settings.FILE_STORAGE_PATH, unique)
+        with open(dest, "wb") as out:
+            out.write(await f.read())
+
+        doc = models.CaseDocument(
+            case_id=case_id,
+            filename=f.filename,
+            path=dest,
+        )
+        db.add(doc)
+        saved += 1
+
+    await db.commit()
+    return {"ok": True, "uploaded": saved}
+
+
+@router.get("/{case_id}/documents", response_model=list[schemas.DocumentRead])
+async def list_documents(case_id: int, db: AsyncSession = Depends(get_async_session)):
+    case = await db.get(models.Case, case_id)
+    if not case:
+        raise HTTPException(404, "Case not found")
+    res = await db.execute(
+        select(models.CaseDocument).where(models.CaseDocument.case_id == case_id)
+    )
+    return res.scalars().all()
+
+
+@router.get("/{case_id}/documents/{doc_id}")
+async def download_document(
+    case_id: int, doc_id: int, db: AsyncSession = Depends(get_async_session)
+):
+    doc = await db.get(models.CaseDocument, doc_id)
+    if not doc or doc.case_id != case_id:
+        raise HTTPException(404, "Document not found")
+    return FileResponse(path=doc.path, filename=doc.filename)
+

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
 
     # --- API ---
     SECRET_KEY: str = "CHANGE_ME_TO_RANDOM_32_CHARS"
+    FILE_STORAGE_PATH: str = "/app/data/uploads"
 
     class Config:
         env_file = ".env"

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -19,3 +19,18 @@ class Case(Base):
     created_at: Mapped[str] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     category: Mapped["Category"] = relationship(lazy="joined")
+    documents: Mapped[list["CaseDocument"]] = relationship(back_populates="case")
+
+
+class CaseDocument(Base):
+    __tablename__ = "case_documents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    case_id: Mapped[int] = mapped_column(ForeignKey("cases.id"))
+    filename: Mapped[str] = mapped_column(String(200))
+    path: Mapped[str] = mapped_column(String(300))
+    uploaded_at: Mapped[str] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    case: Mapped["Case"] = relationship(back_populates="documents")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -18,3 +18,13 @@ class CaseRead(CaseCreate):
     category: CategoryRead
     class Config:
         from_attributes = True
+
+
+class DocumentRead(BaseModel):
+    id: int
+    case_id: int
+    filename: str
+    uploaded_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/migrations/versions/e7d6a5b3d9bc_case_documents.py
+++ b/backend/migrations/versions/e7d6a5b3d9bc_case_documents.py
@@ -1,0 +1,32 @@
+"""add case documents
+
+Revision ID: e7d6a5b3d9bc
+Revises: 541e774f733c
+Create Date: 2025-06-30 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'e7d6a5b3d9bc'
+down_revision: Union[str, None] = '541e774f733c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'case_documents',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('case_id', sa.Integer(), sa.ForeignKey('cases.id'), nullable=False),
+        sa.Column('filename', sa.String(length=200), nullable=False),
+        sa.Column('path', sa.String(length=300), nullable=False),
+        sa.Column('uploaded_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('case_documents')

--- a/frontend/src/pages/NewCase.tsx
+++ b/frontend/src/pages/NewCase.tsx
@@ -13,6 +13,7 @@ export default function NewCase() {
   const [title, setTitle]            = useState("");
   const [description, setDescription]= useState("");
   const [categoryId, setCategoryId]  = useState<number | "">("");
+  const [files, setFiles]            = useState<FileList | null>(null);
 
   const navigate = useNavigate();
 
@@ -28,11 +29,19 @@ export default function NewCase() {
     e.preventDefault();
     if (categoryId === "") return alert("Выберите категорию");
 
-    await http.post("/cases/", {
+    const { data } = await http.post("/cases/", {
       title,
       description,
       category_id: Number(categoryId),
     });
+
+    if (files && files.length) {
+      const fd = new FormData();
+      Array.from(files).forEach(f => fd.append("files", f));
+      await http.post(`/cases/${data.id}/documents`, fd, {
+        headers: { "Content-Type": "multipart/form-data" },
+      });
+    }
 
     navigate("/");      // назад к списку дел
   };
@@ -72,6 +81,13 @@ export default function NewCase() {
           <option key={c.id} value={c.id}>{c.name}</option>
         ))}
       </select>
+
+      {/* ─ документы ─ */}
+      <input
+        type="file"
+        multiple
+        onChange={e => setFiles(e.target.files)}
+      />
 
       {/* ─ submit ─ */}
       <button


### PR DESCRIPTION
## Summary
- track documents with CaseDocument model
- expose FILE_STORAGE_PATH setting
- store uploads and implement document routes
- migrate DB for new case_documents table
- upload files from frontend case creation form

## Testing
- `python3 -m py_compile backend/app/models.py backend/app/schemas.py backend/app/core/config.py backend/app/api/cases.py backend/migrations/versions/e7d6a5b3d9bc_case_documents.py`
- `python3 -m alembic -c backend/alembic.ini upgrade head` *(fails: No module named alembic)*

------
https://chatgpt.com/codex/tasks/task_e_685ffe4275cc8333b49eea9d52a79478